### PR TITLE
Add Strict MethodNotAlowed for /get_with_body

### DIFF
--- a/src/main/java/clientApplication/MethodNotAllowed.java
+++ b/src/main/java/clientApplication/MethodNotAllowed.java
@@ -12,7 +12,7 @@ public class MethodNotAllowed implements Application {
         HttpResponse response = new HttpResponse();
         response.status = "405";
         response.headers = new ArrayList<String>() {{
-            add("Allow: HEAD, OPTIONS");
+            add("Allow: GET, HEAD, OPTIONS");
         }};
 
         return response;

--- a/src/main/java/http/HttpMethod.java
+++ b/src/main/java/http/HttpMethod.java
@@ -1,5 +1,5 @@
 package http;
 
 public enum HttpMethod {
-    POST, GET, HEAD, OPTIONS
+    POST, GET, HEAD, OPTIONS, DELETE, PUT, PATCH
 }

--- a/src/main/java/main/Main.java
+++ b/src/main/java/main/Main.java
@@ -8,6 +8,7 @@ import server.HostConnection;
 import server.Logger;
 import server.Server;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Map;
@@ -37,6 +38,9 @@ public class Main {
                 Map.entry(new RouteId(HttpMethod.GET, "/get_with_body"), new SimpleHelloWorld()),
                 Map.entry(new RouteId(HttpMethod.OPTIONS, "/get_with_body"), new OptionsGetWithBody()),
                 Map.entry(new RouteId(HttpMethod.POST, "/get_with_body"), new MethodNotAllowed()),
+                Map.entry(new RouteId(HttpMethod.DELETE, "/get_with_body"), new MethodNotAllowed()),
+                Map.entry(new RouteId(HttpMethod.PATCH, "/get_with_body"), new MethodNotAllowed()),
+                Map.entry(new RouteId(HttpMethod.PUT, "/get_with_body"), new MethodNotAllowed()),
                 Map.entry(new RouteId(HttpMethod.OPTIONS, "/method_options"), new MethodOption()),
                 Map.entry(new RouteId(HttpMethod.OPTIONS, "/method_options2"), new MethodOptionB())
         );


### PR DESCRIPTION
Add MethodNotAllowed message for the following verbs (assuming the request path is /get_with_body):

* DELETE
* POST
* PATCH
* PUT